### PR TITLE
Python 3.6 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 dist: xenial
 python:
+- '3.6'
 - '3.7'
 - '3.8'
 install:

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,15 @@ from socialscan import __version__
 
 here = path.abspath(path.dirname(__file__))
 
+install_requires = [
+    'dataclasses;python_version<"3.7"',
+    'colorama',
+    'aiohttp>=3.5.0',
+    'tqdm>=4.31.0'
+]
+
+tests_requires = ["pytest>=4.4.0", "flake8", "pytest-xdist"]
+
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
@@ -25,12 +34,16 @@ setup(
         'Operating System :: OS Independent',
         'Topic :: Utilities',
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
     keywords='email email-checker username username-checker social-media',
     packages=['socialscan'],
-    python_requires='>=3.7',
-    install_requires=['colorama', 'aiohttp>=3.5.0', 'tqdm>=4.31.0'],
+    python_requires='>=3.6',
+    install_requires=install_requires,
+    extras_require={
+        "tests": install_requires + tests_requires,
+    },
     entry_points={
         'console_scripts': [
             'socialscan=socialscan.__main__:main',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'tqdm>=4.31.0'
 ]
 
-tests_requires = ["pytest>=4.4.0", "flake8", "pytest-xdist"]
+tests_requires = ["tox", "flake8"]
 
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()

--- a/socialscan/__main__.py
+++ b/socialscan/__main__.py
@@ -18,7 +18,11 @@ def main():
         else:
             if not isinstance(asyncio.get_event_loop_policy(), WindowsSelectorEventLoopPolicy):
                 asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
-    asyncio.run(cli.main())
+    if sys.version_info >= (3, 7):
+        asyncio.run(cli.main())
+    else:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(cli.main())
 
 
 if __name__ == "__main__":

--- a/socialscan/cli.py
+++ b/socialscan/cli.py
@@ -34,6 +34,8 @@ async def main():
     colorama.init(autoreset=True)
     if sys.version_info >= (3, 7):
         sys.stdout.reconfigure(encoding='utf-8')
+    else:
+        sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf8', buffering=1)
     parser = argparse.ArgumentParser(description="Command-line interface for checking email address and username usage on online platforms: " + ", ".join(p.value.__name__ for p in Platforms))
     parser.add_argument("queries", metavar="query", nargs="*",
                         help="one or more usernames/email addresses to query (email addresses are automatically be queried if they match the format)")

--- a/socialscan/cli.py
+++ b/socialscan/cli.py
@@ -32,7 +32,8 @@ COLOUR_ERROR = (Fore.RED, Fore.RED)
 async def main():
     start_time = time.time()
     colorama.init(autoreset=True)
-    sys.stdout.reconfigure(encoding='utf-8')
+    if sys.version_info >= (3, 7):
+        sys.stdout.reconfigure(encoding='utf-8')
     parser = argparse.ArgumentParser(description="Command-line interface for checking email address and username usage on online platforms: " + ", ".join(p.value.__name__ for p in Platforms))
     parser.add_argument("queries", metavar="query", nargs="*",
                         help="one or more usernames/email addresses to query (email addresses are automatically be queried if they match the format)")

--- a/socialscan/util.py
+++ b/socialscan/util.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import re
+import sys
 
 import aiohttp
 
@@ -75,4 +76,11 @@ def sync_execute_queries(queries, platforms=list(Platforms), proxy_list=[]):
     Returns:
         `list` of `PlatformResponse` objects in the same order as the list of queries and platforms passed.
     """
-    return asyncio.run(execute_queries(queries, platforms, proxy_list))
+
+    if sys.version_info >= (3, 7):
+        return asyncio.run(execute_queries(queries, platforms, proxy_list))
+    else:
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(execute_queries(queries, platforms, proxy_list))
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38
+envlist = py36, py37, py38
 skipdist = true
 
 [testenv]


### PR DESCRIPTION
Quite a bunch of quite recent Linux/GNU distros sticks to Python 3.6 as the "LTS" version.
Here's an update to have it work with Python 3.6