### PR TITLE
Added a command line option to exclude platforms.

### DIFF
--- a/socialscan/cli.py
+++ b/socialscan/cli.py
@@ -52,6 +52,13 @@ def init_parser():
         help="list of platforms to query " "(default: all platforms)",
     )
     parser.add_argument(
+        "--exclude",
+        "-e",
+        metavar="exclude",
+        nargs="*",
+        help="list of platforms to exclude " "(default: no platforms)",
+    )
+    parser.add_argument(
         "--view-by",
         dest="view_key",
         choices=["platform", "query"],
@@ -183,6 +190,15 @@ async def main():
                 raise ValueError(p + " is not a valid platform")
     else:
         platforms = [p for p in Platforms]
+
+    if args.exclude:
+        for e in args.exclude:
+            if e.upper() in Platforms.__members__:
+                platform_found = Platforms[e.upper()]
+                platforms.remove(platform_found);
+            else:
+                raise ValueError(e + " is not a valid platform")
+
     proxy_list = []
     if args.proxy_list:
         with open(args.proxy_list, "r") as f:

--- a/socialscan/cli.py
+++ b/socialscan/cli.py
@@ -195,7 +195,8 @@ async def main():
         for e in args.exclude:
             if e.upper() in Platforms.__members__:
                 platform_found = Platforms[e.upper()]
-                platforms.remove(platform_found);
+                if platform_found in platforms:
+                    platforms.remove(platform_found);
             else:
                 raise ValueError(e + " is not a valid platform")
 


### PR DESCRIPTION
I added a new command line option to allow the ability to exclude certain platforms. 
I find this feature to be useful since many of the platforms refuse to work due to token errors or key errors. 
Along with the possibility that said platforms may serve no use to the end user.

The argument works exactly the same as --platforms (-p).

```
$ socialscan user --exclude gitlab --show-urls
```

Let me know if any changes need to be made to the PR, I will respond as soon as I can!

